### PR TITLE
Add url expansion plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ linden.json
 quote.json
 
 .idea
+
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	nosetests

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ $ python3 steelybot.py
 ```
 (`config.py` is in `.gitignore`)
 
+## to run tests
+```
+$ make test
+```
+or simply...
+```
+$ nosetest
+```
+
+If the tests are failing to import, you probably aren't in the virtualenv.
+
 ## credits
 |plugin|author|
 |---|---|
@@ -28,6 +39,7 @@ $ python3 steelybot.py
 |spongemock|[EdwardDowling](https://github.com/EdwardDowling)|
 |train|[izaakf](https://github.com/izaakf)|
 |urbandict|[EdwardDowling](https://github.com/EdwardDowling)|
+|exp|[Byxor](https://github.com/Byxor)|
 
 ## q&a
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fbchat
 requests
 tinydb
 tabulate
+nose

--- a/steely/plugins/url_expander.py
+++ b/steely/plugins/url_expander.py
@@ -1,0 +1,34 @@
+from urllib.request import Request, urlopen
+import json
+
+
+def expand(url):
+    API_ADDRESS = 'http://x.datasig.io/short?url={}'
+    request_url = API_ADDRESS.format(url)
+    request = Request(request_url)
+    response_stream = urlopen(request)
+    response = json.loads(response_stream.read().decode("utf-8"))
+    response_stream.close()
+    expanded_url = response['/short']['destination']
+    return expanded_url
+
+
+# --- Bot-related knowledge ----------------
+
+
+COMMAND = '.exp'
+
+NO_URL_MESSAGE = "Input Error: You didn't provide a URL..."
+
+
+def main(bot, author_id, message, thread_id, thread_type, **kwargs):
+
+    def send(text):
+        bot.sendMessage(text, thread_id=thread_id, thread_type=thread_type)
+
+    if message:
+        short_url = message
+        send(expand(short_url))
+    else:
+        send(NO_URL_MESSAGE)
+

--- a/test/plugins/url_expander_test.py
+++ b/test/plugins/url_expander_test.py
@@ -1,0 +1,20 @@
+import unittest
+from steely.plugins.url_expander import expand
+
+
+class UrlExpansionTest(unittest.TestCase):
+
+    def test_url_expansion(self):
+        url_pairs = [
+            ('https://tinyurl.com/2tx', 'google.com'),
+            ('https://goo.gl/JLGDfs', 'facebook.com'),
+            ('http://bit.ly/1cd2u0N', 'sourmath.com'),
+        ]
+        for short_url, expected_substring in url_pairs:
+            expanded_url = expand(short_url)
+            self.assertIn(expected_substring, expanded_url)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
:white_check_mark: Contains tests.

### Changes:

#### Major

* Adds plugin to expand short URLs.

#### Minor

* Adds Makefile so `make test` can be used (handy).
* Adds `nose` as a requirement.
* Adds emacs backup files to `.gitignore`

### Caveats:
* I haven't tested any bot-related code.
* Tests currently invoke `expand(url)` function that makes HTTP requests.
  * They will fail offline.
  * I chose not to mock and HTTP-related code because I don't want to enforce the idea that the plugin-code should expand URLs via HTTP.