### PR TITLE
Add plugin to evaluate limp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 tinydb
 tabulate
 nose
+limp==0.2

--- a/steely/plugins/limp_evaluation.py
+++ b/steely/plugins/limp_evaluation.py
@@ -27,14 +27,11 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     def send(text):
         bot.sendMessage(text, thread_id=thread_id, thread_type=thread_type)
 
-    def sendError(error):
-        send("Sorry, you have an error: {}".format(error))
-        
     source_code = message
     try:
         result = limp.evaluate(source_code)
     except (SyntaxError, NameError) as e:
-        sendError(e)
+        send("Sorry, you have an error: {}".format(error))
     except Exception as e:
         send("Something unexpected happened: {}".format(e))
         send("Please inform Brandon, thanks.")

--- a/steely/plugins/limp_evaluation.py
+++ b/steely/plugins/limp_evaluation.py
@@ -1,0 +1,42 @@
+'''
+Evaluate limp, a lisp-flavoured language.
+
+Usage: .limp <source_code> 
+
+### Example 1###
+UncleBob: ".limp (+ 2 3)"
+Chat Bot: "5"
+
+### Example 2###
+UncleBob: ".limp (// 100 (- 5 2))"
+Chat Bot: "33"
+
+For more information on how to write limp code, see https://www.github.com/byxor/limp
+Perhaps you feel like contributing to the language! I welcome anything (relevant) that has been fully covered by automatic tests and doesn't limit the architecture.
+'''
+
+
+import limp
+
+
+COMMAND = '.limp'
+
+
+def main(bot, author_id, message, thread_id, thread_type, **kwargs):
+
+    def send(text):
+        bot.sendMessage(text, thread_id=thread_id, thread_type=thread_type)
+
+    def sendError(error):
+        send("Sorry, you have an error: {}".format(error))
+        
+    source_code = message
+    try:
+        result = limp.evaluate(source_code)
+    except SyntaxError as e:
+        sendError(e)
+    except NameError as e:
+        sendError(e)
+    except Exception as e:
+        send("Something unexpected happened: {}".format(e))
+        send("Please inform Brandon, thanks")

--- a/steely/plugins/limp_evaluation.py
+++ b/steely/plugins/limp_evaluation.py
@@ -33,10 +33,8 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     source_code = message
     try:
         result = limp.evaluate(source_code)
-    except SyntaxError as e:
-        sendError(e)
-    except NameError as e:
+    except (SyntaxError, NameError) as e:
         sendError(e)
     except Exception as e:
         send("Something unexpected happened: {}".format(e))
-        send("Please inform Brandon, thanks")
+        send("Please inform Brandon, thanks.")


### PR DESCRIPTION
Allows users to evaluate [limp](https://www.github.com/byxor/limp). 👌 

### Usage examples
```                                       
UncleBob: ".limp (+ 2 3)"
Chat_Bot: "5"
```                                    
```
UncleBob: ".limp (// 100 (- 5 2))"
Chat_Bot: "33"
```

:warning: Plugin comes with no tests, limp is already tested as its own python package.

### Notes
* Remember to **re-install pip dependencies** after merging.