### PR TITLE
Add multiple improvements to limp_evaluation plugin

### DIFF
--- a/steely/plugins/limp_evaluation.py
+++ b/steely/plugins/limp_evaluation.py
@@ -18,20 +18,28 @@ I welcome anything (relevant) that has been fully covered by automatic tests and
 
 
 import limp
+import limp.environment
 
 
 COMMAND = '.limp'
 
 
 def main(bot, author_id, source_code, thread_id, thread_type, **kwargs):
-    def send(text):
-        bot.sendMessage(text, thread_id=thread_id, thread_type=thread_type)
+    def send(x):
+        bot.sendMessage(str(x), thread_id=thread_id, thread_type=thread_type)
+
+    def sendError(info, error):
+        _full_error_message = '{type(error).__name__}: {str(error)}'
+        send(f'{info}: {_full_error_message}')
 
     try:
-        result = limp.evaluate(source_code)
+        environment = environment.create_standard()
+        environment['send'] = send
+        result = limp.evaluate(source_code, environment)
         send(result)
     except (SyntaxError, NameError) as error:
-        send(f'you have an error: {error}')
+        sendError('You have an error', error)
     except Exception as error:
-        send(f'something unexpected happened: {error}')
-        send('please inform Brandon')
+        sendError('Something unexpected happened', error)
+        send('It\'s possible that it\'s your fault.')
+

--- a/steely/plugins/limp_evaluation.py
+++ b/steely/plugins/limp_evaluation.py
@@ -33,7 +33,7 @@ def main(bot, author_id, source_code, thread_id, thread_type, **kwargs):
         send(f'{info}: {_full_error_message}')
 
     try:
-        environment = environment.create_standard()
+        environment = limp.environment.create_standard()
         environment['send'] = send
         result = limp.evaluate(source_code, environment)
         send(result)


### PR DESCRIPTION
### Problems Fixed:
1. If the return value of `limp.evaluate` is 0, it will now send properly.
2. Error messages now have their types displayed when sent.

### New Features:
1. `send` is now an available function for steely. It will send a message to the chat. _(Bear in mind that LIMP doesn't have strings yet, so we can only send ints and floats)_

### Potential Problems:
* I haven't ran/tested anything that has been added here.
* I've never used f-strings before, so it's possible that I've made a mistake.