### PR TITLE
Add .gex stats

### DIFF
--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -14,11 +14,16 @@ CARD_DB = TinyDB('databases/gex_cards.json')
 USER_DB = TinyDB('databases/gex_users.json')
 CARD = Query()
 USER = Query() # not sure if this is needed instead of reusing CARD but w/e
-GOD_IDS = set(['100018746416184', '100022169435132', '100003244958231']) # IDs that don't need auth to create cards (ie. Reed)
+
+# IDs that don't need auth to create cards (ie. Reed)
+GOD_IDS = set(['100018746416184', '100022169435132', '100003244958231']) 
 # cache to map facebook user IDs to real names
 ID_TO_NAME = {}
-# a dict mapping card_id to a list of user_ids who possess that card.
+# A dict mapping card_id to a list of user_ids who possess that card.
+# This dict is not kept in a DB, but is recalculated on each server init.
+# This makes consistency with USER_DB's data much easier.
 CARD_TO_USER_ID = {}
+# Maximum length for a card id.
 MAX_CARD_ID_LENGTH = 16
 
 # Utility funcs

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -306,6 +306,10 @@ def _gex_inspect(bot, args, author_id, thread_id, thread_type):
         info += '_{}_\n\n'.format(deets['desc'])
     masters = [_user_id_to_name(bot, master) for master in deets['masters']]
     info += 'Masters:\n' + ',\n'.join(masters)
+    owner_quants = CARD_TO_USER_ID[deets['id']]
+    owner_quants = sorted(owner_quants, key = lambda x: x[1], reverse=True)
+    owners = [_user_id_to_name(bot, owner_quant[0]) for owner_quant in owner_quants]
+    info += '\n\nOwners:\n' + ',\n'.join(owners)
     bot.sendMessage(info, thread_id=thread_id, thread_type=thread_type)
 
 def _gex_decks(bot, args, author_id, thread_id, thread_type):

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -28,6 +28,8 @@ ID_TO_NAME = {}
 CARD_TO_USER_ID = {}
 # Maximum length for a card id.
 MAX_CARD_ID_LENGTH = 16
+# Scrabble scores for each letter.
+SCRABBLE_SCORES = {"a": 1, "c": 3, "b": 3, "e": 1, "d": 2, "g": 2, "f": 4, "i": 1, "h": 4, "k": 5, "j": 8, "m": 3, "l": 1, "o": 1, "n": 1, "q": 10, "p": 3, "s": 1, "r": 1, "u": 1, "t": 1, "w": 4, "v": 4, "y": 4, "x": 8, "z": 10}
 
 # Utility funcs
 
@@ -87,6 +89,17 @@ def _load_card_to_user_id():
                 CARD_TO_USER_ID[card_id].append((user_id, cards[card_id]))
             else:
                 CARD_TO_USER_ID[card_id] = [(user_id, cards[card_id])]
+
+def _get_scrabble_score(s):
+    ans = 0
+    for c in s.lower():
+        if not c.isalpha():
+            continue
+        if c in SCRABBLE_SCORES:
+            ans += SCRABBLE_SCORES[c]
+        else:
+            ans += 2
+    return ans
 
 # Public API
 
@@ -349,6 +362,7 @@ def _gex_stats(bot, args, author_id, thread_id, thread_type):
     most_circulated_cards = heapq.nlargest(number_of_top_cards_to_list, num_in_circulation, key=lambda x: num_in_circulation[x])
     least_owned_cards = heapq.nsmallest(number_of_bottom_cards_to_list, num_owners, key=lambda x: num_owners[x])
     least_circulated_cards = heapq.nsmallest(number_of_bottom_cards_to_list, num_in_circulation, key=lambda x: num_in_circulation[x])
+    highest_scrabble_scores = heapq.nlargest(number_of_top_cards_to_list, data, key=lambda x: _get_scrabble_score(x))
     out = 'Cards owned by the most people (top 20%):'
     for card in most_owned_cards:
         out += '\n{} ({})'.format(card, num_owners[card])
@@ -365,7 +379,10 @@ def _gex_stats(bot, args, author_id, thread_id, thread_type):
     for card in least_circulated_cards:
         out += '\n{} ({})'.format(card, num_in_circulation[card])
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
-
+    out = 'Cards with the highest scrabble score for their ID (top 20%):'
+    for card in highest_scrabble_scores:
+        out += '\n{} ({})'.format(card, _get_scrabble_score(card))
+    bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     
 
 SUBCOMMANDS = {

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -329,19 +329,15 @@ def _gex_inspect(bot, args, author_id, thread_id, thread_type):
 
 def _gex_decks(bot, args, author_id, thread_id, thread_type):
     users = gex_decks()
-    print(users)
     format_str = '{:<16} {:>4} {:>5} {:>' + str(MAX_CARD_ID_LENGTH) + '}'
     out_strings = [format_str.format('Name', 'Uniq', 'Total', 'Most recent')]
     for user_id, unique, total, last_card in users:
-        print('doing', user_id, unique, total)
         name = _user_id_to_name(bot, user_id)
-        print(name, 'done')
         if last_card is None:
             last_card = ''
         name_line = format_str.format(name[:16], str(unique), str(total), last_card[:MAX_CARD_ID_LENGTH])
         out_strings.append(name_line)
     out = '```\n' + '\n'.join(out_strings) + '\n```'
-    print(out)
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
 
 

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -255,7 +255,7 @@ def _gex_flex(bot, args, author_id, thread_id, thread_type):
     output += 'Total cards: _{}_ (_{}_ unique)\n'.format(total, len(cards))
     output += '\n*Cards*:\n'
     for card, num in cards:
-        output += '`{}`: {}\n'.format(card, num)
+        output += '`{}`: {}\n'.format(card[:MAX_CARD_ID_LENGTH], num)
     bot.sendMessage(output, thread_id=thread_id, thread_type=thread_type)
 
 def _gex_inspect(bot, args, author_id, thread_id, thread_type):
@@ -292,7 +292,7 @@ def _gex_decks(bot, args, author_id, thread_id, thread_type):
 
 
 def _gex_codex(bot, args, author_id, thread_id, thread_type):
-    card_ids = gex_codex()
+    card_ids = [c[:MAX_CARD_ID_LENGTH] for c in gex_codex()]
     message = '\n'.join(card_ids)
     bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)
 

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -6,6 +6,7 @@ See design doc at: https://docs.google.com/document/d/1HYDU3wrewmk9dwt6wX7MqMcbZ
 '''
 
 import time
+import heapq
 from tinydb import TinyDB, Query, where, operations
 
 __author__ = 'iandioch'
@@ -336,8 +337,36 @@ def _gex_codex(bot, args, author_id, thread_id, thread_type):
     bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)
 
 def _gex_stats(bot, args, author_id, thread_id, thread_type):
-    bot.sendMessage('hi', thread_id=thread_id, thread_type=thread_type)
-    bot.sendMessage(str(CARD_TO_USER_ID), thread_id=thread_id, thread_type=thread_type)
+    data = CARD_TO_USER_ID
+    number_of_top_cards_to_list = len(data)//5
+    number_of_bottom_cards_to_list = len(data)//10
+    num_owners = {}
+    num_in_circulation = {}
+    for card in data:
+        num_owners[card] = len(data[card])
+        num_in_circulation[card] = sum(q[1] for q in data[card])
+    most_owned_cards = heapq.nlargest(number_of_top_cards_to_list, num_owners, key=lambda x: num_owners[x])
+    most_circulated_cards = heapq.nlargest(number_of_top_cards_to_list, num_in_circulation, key=lambda x: num_in_circulation[x])
+    least_owned_cards = heapq.nsmallest(number_of_bottom_cards_to_list, num_owners, key=lambda x: num_owners[x])
+    least_circulated_cards = heapq.nsmallest(number_of_bottom_cards_to_list, num_in_circulation, key=lambda x: num_in_circulation[x])
+    out = 'Cards owned by the most people (top 20%):'
+    for card in most_owned_cards:
+        out += '\n{} ({})'.format(card, num_owners[card])
+    bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
+    out = 'Cards with the most copies in circulation (top 20%):'
+    for card in most_circulated_cards:
+        out += '\n{} ({})'.format(card, num_in_circulation[card])
+    bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
+    out = 'Cards owned by the fewest people (bottom 10%):'
+    for card in least_owned_cards:
+        out += '\n{} ({})'.format(card, num_owners[card])
+    bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
+    out = 'Cards with the fewest copies in circulation (bottom 10%):'
+    for card in least_circulated_cards:
+        out += '\n{} ({})'.format(card, num_in_circulation[card])
+    bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
+
+    
 
 SUBCOMMANDS = {
     'give': _gex_give,


### PR DESCRIPTION
Adds:

- Limits to card ID lengths when printing some stuff to stop it looking daft.
- A list of card owners to `.gex inspect`.
- `.gex decks`, which lists users in order of the number of cards they have.
- `.gex stats`, which gives some statistics on the state of the gex kingdom.
- A cleaner help thing, and autocorrect of subcommands, because I need a new hobby.

<img width="834" alt="screen shot 2017-09-27 at 22 51 33" src="https://user-images.githubusercontent.com/3165422/30937218-6f09f16e-a3d6-11e7-83ef-0690bc9e13b9.png">
<img width="828" alt="screen shot 2017-09-27 at 22 52 14" src="https://user-images.githubusercontent.com/3165422/30937251-8943f548-a3d6-11e7-9a14-79f15dc0ae1e.png">
