### PR TITLE
Add Facebook Formatting Helpers

### DIFF
--- a/steely/formatting.py
+++ b/steely/formatting.py
@@ -1,0 +1,17 @@
+bold          = lambda text: _wrap(text, '*')
+italic        = lambda text: _wrap(text, '_')
+monospace     = lambda text: _wrap(text, '`')
+strikethrough = lambda text: _wrap(text, '~')
+
+
+def code_block(text):
+    TAG = '```'
+    NEW_LINE = '\n'
+    return _wrap(text, f'{TAG}{NEW_LINE}', f'{NEW_LINE}{TAG}')
+
+
+def _wrap(text, prefix, suffix=None):
+    if suffix == None:
+        suffix = prefix
+    return f'{prefix}{text}{suffix}'
+

--- a/steely/plugins/_lastfm_helpers.py
+++ b/steely/plugins/_lastfm_helpers.py
@@ -18,8 +18,7 @@ REQUEST_PARAMETERS = {'api_key': config.LASTFM_API_KEY,
 
 def get_lastfm_request(method, **kwargs):
     ''' make a normal python request to the last.fm api
-        return a Response()
-    '''
+        return a Response() '''
     return requests.get(API_BASE, params={"method": method,
                                           **REQUEST_PARAMETERS,
                                           **kwargs})
@@ -28,16 +27,14 @@ def get_lastfm_request(method, **kwargs):
 def get_lastfm_asyncrequest(method, **kwargs):
     ''' make an aysnc request using a requests_futures FuturesSession
         to the last.fm api
-        return a Future()
-    '''
+        return a Future() '''
     return SESSION.get(API_BASE, params={"method": method,
                                           **REQUEST_PARAMETERS,
                                           **kwargs})
 
 
 def get_lastfm_asyncrequest_list(method, **kwargs):
-    ''' call get_lastfm_asyncrequest for each user
-    '''
+    ''' call get_lastfm_asyncrequest for each user '''
     for user in USERDB.all():
         username = user["username"]
         yield get_lastfm_asyncrequest(method,

--- a/steely/plugins/_lastfm_history.py
+++ b/steely/plugins/_lastfm_history.py
@@ -3,6 +3,7 @@
 
 from plugins._lastfm_helpers import *
 from operator import itemgetter
+from formatting import *
 
 
 def time_or_now(track):
@@ -27,10 +28,9 @@ def parsed_response(response):
 def gen_reply_string(response):
     if not response:
         raise KeyError('no tracks found')
-    yield '```'
+    yield ''
     for time, artist, track in response:
         yield f'{time:>5} {artist:<15.15} {track:.25}'
-    yield '```'
 
 
 def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
@@ -45,6 +45,6 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
         clean_response = list(parsed_response(response))
         reply_lines = list(gen_reply_string(clean_response))
         reply_body = '\n'.join(reply_lines)
-        send_message(reply_body)
+        send_message(code_block(reply_body))
     except (NameError, KeyError) as exc:
         send_message(exc)

--- a/steely/plugins/_lastfm_list.py
+++ b/steely/plugins/_lastfm_list.py
@@ -1,5 +1,6 @@
 from plugins._lastfm_helpers import *
 from operator import itemgetter
+from formatting import *
 
 
 def parse_onlines(async_responses):
@@ -38,11 +39,10 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
     usernames = [user["username"] for user in USERDB.all()]
     max_username = max(len(username) for username in usernames)
     stats = zip(list(onlines), usernames, list(playcounts))
-    message = "```\n"
+    message = ""
     for online, username, playcount in sorted(stats, key=itemgetter(0, 2), reverse=True):
         if playcount == 0:
             continue
         online_str = " ♬"[online]
         message += f"{online_str} {username:<{max_username}} {playcount:>6,}\n"
-    message += "```"
-    bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage(code_block(message), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/_lastfm_np.py
+++ b/steely/plugins/_lastfm_np.py
@@ -1,11 +1,11 @@
 from plugins._lastfm_helpers import *
 import json
 from contextlib import suppress
+from formatting import *
 
 
 def parse_tags(response):
-    ''' parse artist.getTopTags and return the top 3 tags
-    '''
+    ''' parse artist.getTopTags and return the top 3 tags '''
     for tag in response.json()['toptags']['tag'][:3]:
         tag_name = tag['name']
         if tag_name in ('seen live', ):
@@ -46,7 +46,7 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
     is_was = "is" if "@attr" in latest_track_obj and \
         "nowplaying" in latest_track_obj["@attr"] else "was"
     tags_or_no = f"\ntags: {tags}" if tags else ''
-    bot.sendMessage(f"{username} {is_was} playing _{track}_ by *{artist}*" + \
+    bot.sendMessage(f"{username} {is_was} playing {italic(track)} by {bold(artist)}" + \
                     f"{tags_or_no}\n{link}",
                     thread_id=thread_id, thread_type=thread_type)
 

--- a/steely/plugins/_lastfm_top.py
+++ b/steely/plugins/_lastfm_top.py
@@ -1,9 +1,9 @@
 from plugins._lastfm_helpers import *
+from formatting import *
 
 
 def parse_top(response):
-    ''' parse arist.getTopArtists and return the artist objects
-    '''
+    ''' parse arist.getTopArtists and return the artist objects '''
     for artist in response.json()['topartists']['artist']:
         yield artist["name"], int(artist["playcount"])
 
@@ -19,7 +19,7 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
         username = message_parts[1]
     else:
         username = USERDB.get(USER.id == author_id)["username"]
-    artists, string = [], "```"
+    artists, string = [], ""
     topartsts_response = get_lastfm_request('user.getTopArtists',
             period=period, user=username, limit=8)
     artists = list(parse_top(topartsts_response))
@@ -27,4 +27,4 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
     max_plays = max(len(str(plays)) for artists, plays in artists)
     for artist, playcount in artists:
         string += f"\n{artist:<{max_artist}} {playcount:>{max_plays}}"
-    bot.sendMessage(string + "```", thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage(code_block(string), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/b.py
+++ b/steely/plugins/b.py
@@ -1,3 +1,5 @@
+from formatting import *
+
 __author__ = 'byxor'
 COMMAND = '.b'
 
@@ -13,10 +15,6 @@ def encode(string):
 
 
 def help():
-    def code_block(contents):
-        tag = "```"
-        return tag + contents + tag
-
     return code_block(f"{COMMAND} {encode('will transform the previous message into something a bit more exciting.')}",)
 
 

--- a/steely/plugins/box.py
+++ b/steely/plugins/box.py
@@ -6,25 +6,28 @@ the text must be between 6 and 19 characters.
 '''
 
 import random
+from formatting import *
 
 
 __author__ = 'sentriz'
 COMMAND = '.box'
 
 
+DIAGONAL = '/'
+GAP = ' '
+
+
 def gen_box(word):
-    yield '```'
-    yield ' '*6 + ' '.join(word)
-    yield ' '*4 + '/' + ' ' + word[1] + ' '*(2*len(word)-5) + '/' + ' ' + word[-2]
-    yield ' '*2 + '/' + ' '*3 + word[2] + ' '*(2*len(word)-7) + '/' + ' '*3 + word[-3]
-    yield ' '.join(word) + ' '*5 + word[-4]
+    yield GAP*6 + GAP.join(word)
+    yield GAP*4 + DIAGONAL + GAP + word[1] + GAP*(2*len(word)-5) + DIAGONAL + GAP + word[-2]
+    yield GAP*2 + DIAGONAL + GAP*3 + word[2] + GAP*(2*len(word)-7) + DIAGONAL + GAP*3 + word[-3]
+    yield GAP.join(word) + GAP*5 + word[-4]
     for n in range(len(word) - 5):
-        yield word[n + 1] + ' '*5 + word[n+4] + ' '*(2*len(word) - 9) + word[-n-2] + ' '*5 + word[-n+len(word)-5]
-    yield word[-4] + ' '*5 + ' '.join(word[::-1])
-    yield word[-3] + ' '*3 + '/' + ' '*(2*len(word)-7) + word[2] + ' '*3 + '/'
-    yield word[-2] + ' ' + '/' + ' '*(2*len(word)-5) + word[1] + ' /'
-    yield ' '.join(word[::-1])
-    yield '```'
+        yield word[n + 1] + GAP*5 + word[n+4] + GAP*(2*len(word) - 9) + word[-n-2] + GAP*5 + word[-n+len(word)-5]
+    yield word[-4] + GAP*5 + GAP.join(word[::-1])
+    yield word[-3] + GAP*3 + DIAGONAL + GAP*(2*len(word)-7) + word[2] + GAP*3 + DIAGONAL
+    yield word[-2] + GAP + DIAGONAL + GAP*(2*len(word)-5) + word[1] + GAP + DIAGONAL
+    yield GAP.join(word[::-1])
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
@@ -32,6 +35,6 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
         bot.sendMessage('word please', thread_id=thread_id, thread_type=thread_type)
     elif 5 < len(message) < 20:
         box = '\n'.join(gen_box(message))
-        bot.sendMessage(box, thread_id=thread_id, thread_type=thread_type)
+        bot.sendMessage(code_block(box), thread_id=thread_id, thread_type=thread_type)
     else:
         bot.sendMessage("can't use \"{}\"".format(message), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/bus.py
+++ b/steely/plugins/bus.py
@@ -11,6 +11,7 @@ import json
 import operator
 import re
 import requests
+from formatting import *
 
 
 __author__ = 'alexkraak'
@@ -52,7 +53,7 @@ def gen_reply_string(arrivals):
     def max_string(column):
         return max(len(str(arrival[column])) for arrival in arrivals)
     max_route, max_dest, max_duetime = map(max_string, COLUMNS)
-    yield "```"
+    yield ""
     for arrival in sorted(arrivals, key=arrival_sort):
         due_suffix, extra_due_padding = 'min', 0
         if arrival['duetime'] == 'due':
@@ -61,7 +62,6 @@ def gen_reply_string(arrivals):
         yield f'{arrival["route"]:<{max_route}} ' + \
               f'{arrival["destination"]:<{max_dest}} ' + \
               f'{arrival["duetime"]:>{max_duetime + extra_due_padding}}{due_suffix}'
-    yield "```"
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
@@ -74,7 +74,7 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     if not arrivals:
         send_message("no buses found >:(")
         return
-    send_message("\n".join(gen_reply_string(arrivals)))
+    send_message(code_block("\n".join(gen_reply_string(arrivals))))
 
 
 if __name__ == "__main__":

--- a/steely/plugins/define.py
+++ b/steely/plugins/define.py
@@ -12,6 +12,7 @@ They can be accessed via ~<command_name>, and will output what you put in.
 
 
 from tinydb import TinyDB, Query
+from formatting import *
 
 
 __author__ = 'alexkraak'
@@ -25,7 +26,7 @@ ANGRY_STRING = 'please use in form .define <command_name> <command text>'
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     if message == 'list':
         user_cmds = ', '.join((command['cmd'] for command in CMD_DB))
-        bot.sendMessage(f'```\n{user_cmds}\n```', thread_id=thread_id, thread_type=thread_type)
+        bot.sendMessage(code_block(user_cmds), thread_id=thread_id, thread_type=thread_type)
         return
     if not ' ' in message:
         bot.sendMessage(ANGRY_STRING, thread_id=thread_id, thread_type=thread_type)
@@ -34,7 +35,7 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     if command == 'code':
         if ' ' in text:
             command, text = text.split(' ', 1)
-            text = f'```\n{text}\n```'
+            text = code_block(text)
         else:
             bot.sendMessage(ANGRY_STRING, thread_id=thread_id, thread_type=thread_type)
             return

--- a/steely/plugins/eight.py
+++ b/steely/plugins/eight.py
@@ -27,7 +27,8 @@ REPLIES = (
     "my reply is no",
     "my sources say no",
     "outlook not so good",
-    "very doubtful"
+    "very doubtful",
+    "i have no idea",
 )
 
 

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -9,6 +9,7 @@ import time
 import heapq
 import difflib
 from tinydb import TinyDB, Query, where, operations
+from formatting import *
 
 __author__ = 'iandioch'
 COMMAND = '.gex'
@@ -304,11 +305,11 @@ def _gex_flex(bot, args, author_id, thread_id, thread_type):
     cards = gex_flex(user_id)
     total = sum(c[1] for c in cards)
     name = _user_id_to_name(bot, user_id)
-    output = '*{}*\nID: _{}_\n'.format(name, user_id)
+    output = '{}\nID: _{}_\n'.format(bold(name), user_id)
     output += 'Total cards: _{}_ (_{}_ unique)\n'.format(total, len(cards))
-    output += '\n*Cards*:\n'
+    output += f'\n{bold(Cards)}:\n'
     for card, num in cards:
-        output += '`{}`: {}\n'.format(card[:MAX_CARD_ID_LENGTH], num)
+        output += '{}: {}\n'.format(monospace(card[:MAX_CARD_ID_LENGTH]), num)
     bot.sendMessage(output, thread_id=thread_id, thread_type=thread_type)
 
 def _gex_inspect(bot, args, author_id, thread_id, thread_type):
@@ -319,9 +320,9 @@ def _gex_inspect(bot, args, author_id, thread_id, thread_type):
     if deets['image'] and deets['image'] is not None:
         print('inspecting image', deets['image'])
         bot.sendRemoteImage(deets['image'], thread_id=thread_id, thread_type=thread_type)
-    info = '*{}*\n'.format(deets['id'])
+    info = '*{}*\n'.format(bold(deets['id']))
     if deets['desc'] is not None:
-        info += '_{}_\n\n'.format(deets['desc'])
+        info += '{}\n\n'.format(italic(deets['desc']))
     masters = [_user_id_to_name(bot, master) for master in deets['masters']]
     info += 'Masters:\n' + ',\n'.join(masters)
     if deets['id'] in CARD_TO_USER_ID:
@@ -341,7 +342,7 @@ def _gex_decks(bot, args, author_id, thread_id, thread_type):
             last_card = ''
         name_line = format_str.format(name[:16], str(unique), str(total), last_card[:MAX_CARD_ID_LENGTH])
         out_strings.append(name_line)
-    out = '```\n' + '\n'.join(out_strings) + '\n```'
+    out = code_block('\n'.join(out_strings))
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
 
 
@@ -365,24 +366,25 @@ def _gex_stats(bot, args, author_id, thread_id, thread_type):
     least_circulated_cards = heapq.nsmallest(number_of_bottom_cards_to_list, num_in_circulation, key=lambda x: num_in_circulation[x])
     highest_scrabble_scores = heapq.nlargest(number_of_top_cards_to_list, data, key=lambda x: _get_scrabble_score(x))
     out = 'Cards owned by the most people (top 20%):'
+    FORMAT = '\n{} ({})'
     for card in most_owned_cards:
-        out += '\n{} ({})'.format(card, num_owners[card])
+        out += FORMAT.format(card, num_owners[card])
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     out = 'Cards with the most copies in circulation (top 20%):'
     for card in most_circulated_cards:
-        out += '\n{} ({})'.format(card, num_in_circulation[card])
+        out += FORMAT.format(card, num_in_circulation[card])
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     out = 'Cards owned by the fewest people (bottom 10%):'
     for card in least_owned_cards:
-        out += '\n{} ({})'.format(card, num_owners[card])
+        out += FORMAT.format(card, num_owners[card])
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     out = 'Cards with the fewest copies in circulation (bottom 10%):'
     for card in least_circulated_cards:
-        out += '\n{} ({})'.format(card, num_in_circulation[card])
+        out += FORMAT.format(card, num_in_circulation[card])
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     out = 'Cards with the highest scrabble score for their ID (top 20%):'
     for card in highest_scrabble_scores:
-        out += '\n{} ({})'.format(card, _get_scrabble_score(card))
+        out += FORMAT.format(card, _get_scrabble_score(card))
     bot.sendMessage(out, thread_id=thread_id, thread_type=thread_type)
     
 def _gex_help(bot, args, author_id, thread_id, thread_type):

--- a/steely/plugins/goth.py
+++ b/steely/plugins/goth.py
@@ -6,7 +6,7 @@ COMMAND = '.goth'
 
 
 NORMAL = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-GOTH = '𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ'
+GOTH =   '𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ'
 GOTH_TRANS = str.maketrans(NORMAL, GOTH)
 
 

--- a/steely/plugins/help.py
+++ b/steely/plugins/help.py
@@ -1,3 +1,6 @@
+from formatting import *
+
+
 __author__ = 'devoxel'
 COMMAND = '.help'
 
@@ -16,5 +19,5 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
         if not plugin in bot.plugin_helps:
             send_message(f'help not found for command {plugin!r}')
             return
-        send_message(f"```\n{bot.plugin_helps[plugin]}\n```")
+        send_message(code_block(bot.plugin_helps[plugin]))
     return

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -23,6 +23,7 @@ from tinydb import TinyDB, Query, where
 from tinydb.operations import increment
 from datetime import datetime, timedelta
 from plugins import gex
+from formatting import *
 import tabulate
 import random
 import requests
@@ -208,14 +209,13 @@ def give_cmd(bot, message_parts, author_id, thread_id, thread_type):
 def table_cmd(bot, message_parts, author_id, thread_id, thread_type):
     max_lindens = len(str(max(user['lindens'] for user in USERDB.all())))
     max_name = len(max((user['first_name'] for user in USERDB.all()), key=len))
-    string = '```'
+    string = ''
     for user in sorted(USERDB.all(), key=lambda user: user['lindens'], reverse=True):
         string += '\n{name:<{max_name}} {lindens:>{max_lindens}.3f}L$'.format(name=user['first_name'],
                                                                          lindens=user['lindens'],
                                                                          max_name=max_name,
                                                                          max_lindens=max_lindens + 4)
-    string += '\n```'
-    bot.sendMessage(string, thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage(code_block(string), thread_id=thread_id, thread_type=thread_type)
 
 
 QUOTE_CACHE = {}
@@ -339,7 +339,7 @@ def invest_list_cmd(user_id, args):
     if user_balance is None:
         return "User does not exist, poke Senan"
     user = USERDB.get(USER.id == user_id)
-    out = "```\n{}: {:.2f}L$ Cash\n\n".format(user['first_name'], user['lindens'])
+    out = "{}: {:.2f}L$ Cash\n\n".format(user['first_name'], user['lindens'])
     total_assets = float(user['lindens'])
     tics = list(user['investments'])
     quotes = invest_get_quotes_w_cache(tics)
@@ -362,8 +362,8 @@ def invest_list_cmd(user_id, args):
         total_profit += (quant * bid) - orig_value
     out += tabulate.tabulate(table, headers=("ticker", "quant", "value", "% profit"), tablefmt="plain", floatfmt=".4f")
     out += "\nCurrent Profit: {:.2f}L$".format(total_profit)
-    out += "\nTotal Assets: {:.2f}L$\n```".format(total_assets)
-    return out
+    out += "\nTotal Assets: {:.2f}L$".format(total_assets)
+    return code_block(out)
 
 
 def invest_quote_cmd(user_id, args):

--- a/steely/plugins/roll.py
+++ b/steely/plugins/roll.py
@@ -10,6 +10,7 @@ for example:
 
 import random
 import re
+from formatting import *
 
 
 __author__ = 'devoxel'
@@ -50,7 +51,7 @@ def dorolls(s):
             out.append(o)
     if len(out) == 0:
         return 'No valid rolls scrub'
-    return '```\n' + '\n'.join(out) + '\n```'
+    return code_block('\n'.join(out))
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     bot.sendMessage(dorolls(message), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/stats.py
+++ b/steely/plugins/stats.py
@@ -7,6 +7,7 @@ show plugin stats
 
 from tinydb import TinyDB, Query
 from operator import itemgetter
+from formatting import *
 
 
 __author__ = 'sentriz'
@@ -29,10 +30,11 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     clean_stats = list(parse_stats(CMD_DB))
     sorted_stats = sort_stats(clean_stats)[:LIMIT]
     max_command = max(len(command) for command, count in sorted_stats)
-    message = f'```\ntop {LIMIT}\n――――――\n'
+    message = f'top {LIMIT}\n――――――\n'
     for command, count in sorted_stats:
         if count == 100:
-            count = '💯'
-        message += f'{command:<{max_command}} {count:>3,}\n'
-    message += '```'
-    bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)
+            representation = '💯'
+        else:
+            representation = count
+        message += f'{command:<{max_command}} {representation:>3,}\n'
+    bot.sendMessage(code_block(message), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/tracker.py
+++ b/steely/plugins/tracker.py
@@ -8,6 +8,7 @@
 
 import requests
 from operator import itemgetter
+from formatting import *
 
 
 __author__ = 'sentriz'
@@ -28,10 +29,10 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     response = requests.get(BASE.format(tracker=message)).json()
     max_service = max(len(key) for key in response)
     max_latency = max(len(info["Latency"]) for info in response.values())
-    string = "```\n"
+    string = ""
     for service, info in sorted(response.items(), key=itemgetter(0)):
         print(service, info)
         string += "{service:<{max_service}} {latency:>{max_latency}}\n".format(
             latency=info["Latency"], **locals())
-    bot.sendMessage(string + "```",
+    bot.sendMessage(code_block(string),
                     thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/train.py
+++ b/steely/plugins/train.py
@@ -10,6 +10,7 @@ import requests
 import re
 from operator import itemgetter
 from xml.etree import ElementTree
+from formatting import *
 
 
 __author__ = 'izaakf'
@@ -47,11 +48,9 @@ def gen_column_widths(times):
 
 def gen_reply_string(times, widths):
     _, max_origin, max_destin, max_time = widths
-    yield "```"
     yield f"  {'from':<{max_origin}} to"
     for direction, origin, destin, time in times:
         yield f"{direction} {origin:<{max_origin}} {destin:<{max_destin}} {time:>{max_time}}min"
-    yield "```"
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
@@ -66,7 +65,7 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     except requests.exceptions.RequestException:
         send_message("error retrieving results")
     if times:
-        send_message("\n".join(gen_reply_string(times, widths)))
+        send_message(code_block("\n".join(gen_reply_string(times, widths))))
     else:
         send_message("no results")
 

--- a/test/formatting_test.py
+++ b/test/formatting_test.py
@@ -1,0 +1,52 @@
+from steely.formatting import *
+from nose.tools import assert_equal
+
+
+def test_code_blocks():
+    data = [
+        ('foo',              '```\nfoo\n```'),
+        ('bar',              '```\nbar\n```'),
+        ('code\ngoes\nhere', '```\ncode\ngoes\nhere\n```'),
+    ]
+    for text, expected_text in data:
+        yield assert_equal, expected_text, code_block(text)
+
+
+def test_bold_text():
+    data = [
+        ('hey',       '*hey*'),
+        ('bold boys', '*bold boys*'),
+        ('\n\n\n', '*\n\n\n*'),
+    ]
+    for text, expected_text in data:
+        yield assert_equal, expected_text, bold(text)
+
+
+def test_italic_text():
+    data = [
+        ('foo',     '_foo_'),
+        ('bar',     '_bar_'),
+        ('b\na\nz', '_b\na\nz_'),
+    ]
+    for text, expected_text in data:
+        yield assert_equal, expected_text, italic(text)
+
+
+def test_monospace_text():
+    data = [
+        ('foo',     '`foo`'),
+        ('bar',     '`bar`'),
+        ('b\na\nz', '`b\na\nz`'),
+]
+    for text, expected_text in data:
+        yield assert_equal, expected_text, monospace(text)
+
+
+def test_strikethrough_text():
+    data = [
+        ('foo', '~foo~'),
+        ('bar', '~bar~'),
+        ('baz', '~baz~'),
+    ]
+    for text, expected_text in data:
+        yield assert_equal, expected_text, strikethrough(text)


### PR DESCRIPTION
`formatting.py` contains helpers that apply text formatting.

✅ `code_block`
✅ `bold`
✅ `italic`
✅ `strikethrough`
✅ `monospace`

It's tested.

I went through a bunch of plugins and changed the duplicate code to use these helpers.
I may have missed some things.
I tried very hard to keep the plugins working. If they had tests, it'd be easy to catch errors quickly.

From now on, please do all your formatting through this library. Replacing the duplication was slightly painful.