### PR TITLE
Add percentage increase to bitcoin plugin

### DIFF
--- a/steely/plugins/btc.py
+++ b/steely/plugins/btc.py
@@ -5,37 +5,34 @@ __author__ = ('CianLR', 'byxor')
 COMMAND = 'btc'
 
 API_URL = 'https://api.coindesk.com/v1/bpi/currentprice.json'
-RESP_TEMPLATE = """Bitcoin Price:
-€{}
+RESP_TEMPLATE = """€{}
 ${}
-Difference since last time: {}"""
-
+difference since last time: {}"""
 LAST_EUROS = 100
 
-class BitcoinException(Exception): pass
-class BadHttpResponse(BitcoinException): pass
-class MissingFields(BitcoinException): pass
+class BitcoinException(Exception):
+    pass
+class BadHTTPResponse(BitcoinException):
+    pass
+class MissingFields(BitcoinException):
+    pass
 
 
 def get_bitcoin_rates():
-    response = requests.get(API_URL)    
-
+    response = requests.get(API_URL)
     if not response.ok:
         message = "Error getting price. Response (code {}) {}".format(
             response.status_code, response.text)
-        raise BadHttpResponse(message)
-    
-    j = response.json()
-    
-    if not _is_valid_response(j):
-        message = "Response is missing fields: {}".format(str(j))
+        raise BadHTTPResponse(message)
+    response_json = response.json()
+    if not _is_valid_response(response_json):
+        message = "Response is missing fields: {}".format(str(response_json))
         raise MissingFields(message)
-    
-    euros = float(j['bpi']['EUR']['rate'])
-    dollars = float(j['bpi']['USD']['rate'])
-    return (euros, dollars)
+    euros = response_json['bpi']['EUR']['rate_float']
+    dollars = response_json['bpi']['USD']['rate_float']
+    return euros, dollars
 
-    
+
 def _is_valid_response(resp):
     return ('bpi' in resp and
             'EUR' in resp['bpi'] and 'rate' in resp['bpi']['EUR'] and
@@ -48,7 +45,7 @@ def percentage_increase(before, after):
 
 
 def percentage_string(n):
-    return "{0:+d}%".format(n)
+    return "{:.3f}%".format(n)
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):

--- a/steely/plugins/btc.py
+++ b/steely/plugins/btc.py
@@ -10,7 +10,7 @@ RESP_TEMPLATE = """Bitcoin Price:
 ${}
 Difference since last time: {}"""
 
-last_euros = 100
+LAST_EUROS = 100
 
 class BitcoinException(Exception): pass
 class BadHttpResponse(BitcoinException): pass
@@ -53,11 +53,11 @@ def percentage_string(n):
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     try:
-        global last_euros
+        global LAST_EUROS
         euros, dollars = get_bitcoin_rates()
-        increase = percentage_increase(last_euros, euros)
+        increase = percentage_increase(LAST_EUROS, euros)
         message = RESP_TEMPLATE.format(euros, dollars, percentage_string(increase))
-        last_euros = euros
+        LAST_EUROS = euros
     except BitcoinException as e:
         message = str(e)
     bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/btc.py
+++ b/steely/plugins/btc.py
@@ -47,9 +47,8 @@ def percentage_increase(before, after):
     return (delta * 100) / before
 
 
-def percentage_string(increase):
-    prefix = "+" if increase >= 0 else ""
-    return prefix + str(increase) + "%"
+def percentage_string(n):
+    return "{0:+d}%".format(n)
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):

--- a/test/plugins/btc_test.py
+++ b/test/plugins/btc_test.py
@@ -1,0 +1,28 @@
+from steely.plugins.btc import *
+from nose.tools import *
+
+
+def test_percentage_increase():
+    data = [
+        (100, 100, 0),
+        (40, 40, 0),
+        (100, 101, 1),
+        (100, 99, -1),
+        (1000, 1010, 1),
+        (1000, 1500, 50),
+        (9000, 9, -99.9),
+    ]
+    for before, after, expected in data:
+        yield assert_equal, expected, percentage_increase(before, after)
+
+
+def test_percentage_string():
+    data = [
+        (0, "+0%"),
+        (1, "+1%"),
+        (123, "+123%"),
+        (-99, "-99%"),
+        (-1122, "-1122%"),
+    ]
+    for percentage_delta, expected_string in data:
+        yield assert_equal, expected_string, percentage_string(percentage_delta)


### PR DESCRIPTION
Now we get a nice little percentage that tells us how much bitcoin has gone up (or down) in value since the last time the command was run.

:moneybag: :chart_with_upwards_trend: :white_check_mark: 

---

**Notes:**

* I've added tests for the simple bits of logic I've added.

* I had to split up the `get_btc` function into smaller pieces; I relied on the rates rather than their string-formatted counterparts.

* The error messages that were returned from `get_btc` have changed to exceptions; this keeps the return type of the `get_bitcoin_rates` function consistent and makes it much easier to report errors to the user.

* I may have made a silly mistake. I'm not able to run most of this code. :warning: