### PR TITLE
Fix bug where arg name is truncated in BASIC

### DIFF
--- a/steely/plugins/basic_interpreter.py
+++ b/steely/plugins/basic_interpreter.py
@@ -127,7 +127,7 @@ class BasicInterpreter:
         if '"' in args:
             self._stdout(args.strip('"'))
         else:
-            self._stdout(str(self._vars[args[0]]))
+            self._stdout(str(self._vars[args.strip()]))
         self._cur_instr = self._next_instr()
 
     def _instr_PRINTLN(self, args):


### PR DESCRIPTION
10 LET R = 0
20 LET RESULT = 1
30 PRINTLN RESULT

Outputs: 0

*But not anymore* 👌