### PR TITLE
Add Haskell plugin

### DIFF
--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -1,0 +1,20 @@
+set -e
+DIRECTORY="temporary"
+EXECUTABLE="$DIRECTORY/main"
+FILENAME="$DIRECTORY/code.hs"
+
+# Clean up
+rm -rf $DIRECTORY
+mkdir $DIRECTORY
+
+# Read code from stdin
+code=$(cat)
+
+# Save code to disk
+echo "$code" > $FILENAME
+
+# Compile code
+ghc -o $EXECUTABLE $FILENAME
+
+# Run code
+./$EXECUTABLE

--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -1,20 +1,31 @@
-set -e
 DIRECTORY="temporary"
 EXECUTABLE="$DIRECTORY/main"
 FILENAME="$DIRECTORY/code.hs"
 
-# Clean up
-rm -rf $DIRECTORY
-mkdir $DIRECTORY
+function _clean_up {
+    rm -rf $DIRECTORY
+    mkdir $DIRECTORY
+}
 
-# Read code from stdin
-code=$(cat)
+function _save {
+    code=$(cat)
+    echo "$code" > $FILENAME
+}
 
-# Save code to disk
-echo "$code" > $FILENAME
+function _compile {
+    ghc -o $EXECUTABLE $FILENAME
+}
 
-# Compile code
-ghc -o $EXECUTABLE $FILENAME
+function _run {
+    echo
+    echo "Output:"
+    ./$EXECUTABLE
+}
 
-# Run code
-./$EXECUTABLE
+set -e
+trap _clean_up EXIT
+
+_clean_up
+_save
+_compile
+_run

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -1,0 +1,44 @@
+# External Dependencies:
+# - firejail (for sandboxing)
+
+
+from subprocess import Popen, PIPE, STDOUT
+from threading import Timer
+
+
+COMMAND = "haskell"
+__doc__ = "Compiles and executes Haskell."
+__author__ = "byxor"
+
+
+SHELL_COMMAND = ["firejail", "bash", "plugins/_haskell.sh"]
+TIMEOUT_IN_SECONDS = 10
+
+
+def main(bot, author_id, code, thread_id, thread_type, **kwargs):
+    bot.sendMessage(attempt_to_run(code), thread_id=thread_id, thread_type=thread_type)
+
+
+def attempt_to_run(code):
+    result = run(code)
+    if result is not None:
+        return result
+    return "Request timed out. Don't be naughty."
+
+
+def run(code):
+    process = Popen(SHELL_COMMAND, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+    timer = Timer(TIMEOUT_IN_SECONDS, process.kill)
+    try:
+        timer.start()
+        return communicate(process, code)
+    finally:
+        timer.cancel()
+
+
+def communicate(process, code):
+    encoding = "utf-8"
+    code_bytes = code.encode(encoding)
+    write_code_to_process = lambda: process.communicate(input=code_bytes)
+    output = write_code_to_process()[0].decode(encoding)
+    return output

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -1,5 +1,6 @@
 # External Dependencies:
 # - firejail (for sandboxing)
+# - ghc (for compiling haskell)
 
 
 from subprocess import Popen, PIPE, STDOUT

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -28,10 +28,6 @@ def attempt_to_run(code):
 
 def run(code):
     process = Popen(SHELL_COMMAND, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
-    return communicate(process, code)
-
-
-def communicate(process, code):
     encoding = "utf-8"
     code_bytes = code.encode(encoding)
     write_code_to_process = lambda: process.communicate(input=code_bytes)

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -11,6 +11,9 @@ __author__ = "byxor"
 
 
 TIMEOUT_IN_SECONDS = 10
+TIMEOUT_MESSAGE = "Request timed out. Don't be naughty."
+
+
 SCRIPT = "plugins/_haskell.sh"
 SHELL_COMMAND = ["firejail", "timeout", f"{TIMEOUT_IN_SECONDS}", "bash", SCRIPT]
 
@@ -22,7 +25,7 @@ def main(bot, author_id, code, thread_id, thread_type, **kwargs):
 def attempt_to_run(code):
     result = run(code)
     if timed_out(result):
-        return "Request timed out. Don't be naughty."
+        return TIMEOUT_MESSAGE
     return result
 
 


### PR DESCRIPTION
* Compiles and executes Haskell in a **sandboxed** environment.
* Times out after 10 seconds so people don't hang the server.
* Requires `firejail` and `ghc` to be installed on server.
* Manually tested with local_steely (seems to work).

### Example 1
```haskell
.haskell main = do print (10 + 20)
```

```
[1 of 1] Compiling Main             ( temporary/code.hs, temporary/code.o )
Linking temporary/main ...

Output:
30
```

### Example 2
```haskell
.haskell
fibonacci :: Integer -> Integer
fibonacci 0 = 1
fibonacci 1 = 1
fibonacci n = fibonacci (n - 1) + fibonacci (n - 2)

main = do
    print $ fibonacci 5
```

```
[1 of 1] Compiling Main             ( temporary/code.hs, temporary/code.o )
Linking temporary/main ...

Output:
8
```

Now we can learn Haskell much easier. Enjoy ✌️ 