### PR TITLE
Add (insanely improved) haskell plugin

### DIFF
--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -21,9 +21,17 @@ function _compile {
 function _run {
     echo
     echo "*Program Output:*"
-    local secondsToWait=10
+    local secondsToWait=4
     local whitelist="$(pwd)/$DIRECTORY"
-    firejail --quiet --noprofile --whitelist=$whitelist timeout $secondsToWait ./$EXECUTABLE
+
+    timeout $secondsToWait firejail --quiet --noprofile --whitelist=$whitelist ./$EXECUTABLE || _checkTimeout
+}
+
+function _checkTimeout {
+    local exitCode=$?
+    if [[ $exitCode -ne 0 ]]; then
+        echo "Program timed out. Don't be cheeky."
+    fi
 }
 
 set -e

--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -1,0 +1,20 @@
+set -e
+DIRECTORY="temporary"
+EXECUTABLE="$DIRECTORY/main"
+FILENAME="$DIRECTORY/code.hs"
+
+# Clean up
+rm -rf $DIRECTORY
+mkdir $DIRECTORY
+
+# Read code from stdin
+code=$(cat)
+
+# Save code to disk
+echo "$code" > $FILENAME
+
+# Compile code
+ghc -o $EXECUTABLE $FILENAME
+
+# Run code
+./$EXECUTABLE

--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -29,7 +29,7 @@ function _run {
 
 function _checkTimeout {
     local exitCode=$?
-    if [[ $exitCode -ne 0 ]]; then
+    if [[ $exitCode -eq 124 ]]; then
         echo "Program timed out. Don't be cheeky."
     fi
 }

--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -13,13 +13,17 @@ function _save {
 }
 
 function _compile {
+    echo
+    echo "*Compiler Output:*"
     ghc -o $EXECUTABLE $FILENAME
 }
 
 function _run {
     echo
-    echo "Output:"
-    ./$EXECUTABLE
+    echo "*Program Output:*"
+    local secondsToWait=10
+    local whitelist="$(pwd)/$DIRECTORY"
+    firejail --quiet --noprofile --whitelist=$whitelist timeout $secondsToWait ./$EXECUTABLE
 }
 
 set -e

--- a/steely/plugins/_haskell.sh
+++ b/steely/plugins/_haskell.sh
@@ -1,20 +1,31 @@
-set -e
 DIRECTORY="temporary"
 EXECUTABLE="$DIRECTORY/main"
 FILENAME="$DIRECTORY/code.hs"
 
-# Clean up
-rm -rf $DIRECTORY
-mkdir $DIRECTORY
+function _clean_up {
+    rm -rf $DIRECTORY
+    mkdir $DIRECTORY
+}
 
-# Read code from stdin
-code=$(cat)
+function _save {
+    code=$(cat)
+    echo "$code" > $FILENAME
+}
 
-# Save code to disk
-echo "$code" > $FILENAME
+function _compile {
+    ghc -o $EXECUTABLE $FILENAME
+}
 
-# Compile code
-ghc -o $EXECUTABLE $FILENAME
+function _run {
+    echo
+    echo "Output:"
+    ./$EXECUTABLE
+}
 
-# Run code
-./$EXECUTABLE
+set -e
+trap _clean_up EXIT
+
+_clean_up
+_save
+_compile
+_run

--- a/steely/plugins/_lastfm_collage.py
+++ b/steely/plugins/_lastfm_collage.py
@@ -18,7 +18,7 @@ def get_collage(author_id, user, period):
 def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
     if not message_parts or message_parts[0] not in PERIODS:
         period_string = '|'.join(PERIODS)
-        bot.sendMessage(f'usage: .np collage <{period_string}> [username]',
+        bot.sendMessage(f'usage: {COMMAND} collage <{period_string}> [username]',
                         thread_id=thread_id, thread_type=thread_type)
         return
     else:

--- a/steely/plugins/_lastfm_np.py
+++ b/steely/plugins/_lastfm_np.py
@@ -29,7 +29,7 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
     elif user:
         username = user['username']
     else:
-        bot.sendMessage('include username please or use .np set',
+        bot.sendMessage(f'include username please or use {COMMAND} set',
                         thread_id=thread_id, thread_type=thread_type)
         return
     latest_track_obj = get_lastfm_request("user.getRecentTracks",

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -11,22 +11,12 @@ __doc__ = "Compiles and executes Haskell."
 __author__ = "byxor"
 
 
-TIMEOUT_MESSAGE = "Request timed out. Don't be naughty."
 
-
-SCRIPT = "plugins/_haskell.sh"
-SHELL_COMMAND = ["bash", SCRIPT]
+SHELL_COMMAND = ["bash", "plugins/_haskell.sh"]
 
 
 def main(bot, author_id, code, thread_id, thread_type, **kwargs):
-    bot.sendMessage(attempt_to_run(code), thread_id=thread_id, thread_type=thread_type)
-
-
-def attempt_to_run(code):
-    result = run(code)
-    if timed_out(result):
-        return TIMEOUT_MESSAGE
-    return result
+    bot.sendMessage(run(code), thread_id=thread_id, thread_type=thread_type)
 
 
 def run(code):
@@ -36,7 +26,3 @@ def run(code):
     write_code_to_process = lambda: process.communicate(input=code_bytes)
     output = write_code_to_process()[0].decode(encoding)
     return output
-
-
-def timed_out(result):
-    return (SCRIPT in result) and ("Terminated" in result)

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -1,0 +1,44 @@
+# External Dependencies:
+# - firejail (for sandboxing)
+
+
+from subprocess import Popen, PIPE, STDOUT
+from threading import Timer
+
+
+COMMAND = "haskell"
+__doc__ = "Compiles and executes Haskell."
+__author__ = "byxor"
+
+
+SHELL_COMMAND = ["firejail", "bash", "plugins/_haskell.sh"]
+TIMEOUT_IN_SECONDS = 10
+
+
+def main(bot, author_id, code, thread_id, thread_type, **kwargs):
+    bot.sendMessage(attempt_to_run(code), thread_id=thread_id, thread_type=thread_type)
+
+
+def attempt_to_run(code):
+    result = run(code)
+    if result is not None:
+        return result
+    return "Request timed out. Don't be naughty."
+
+
+def run(code):
+    process = Popen(SHELL_COMMAND, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+    timer = Timer(TIMEOUT_IN_SECONDS, process.kill)
+    try:
+        timer.start()
+        return communicate(process, code)
+    finally:
+        timer.cancel()
+
+
+def communicate(process, code):
+    encoding = "utf-8"
+    code_bytes = code.encode(encoding)
+    write_code_to_process = lambda: process.communicate(input=code_bytes)
+    output = write_code_to_process()[0].decode(encoding)
+    return output

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -1,5 +1,6 @@
 # External Dependencies:
 # - firejail (for sandboxing)
+# - ghc (for compiling haskell)
 
 
 from subprocess import Popen, PIPE, STDOUT

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -11,12 +11,11 @@ __doc__ = "Compiles and executes Haskell."
 __author__ = "byxor"
 
 
-TIMEOUT_IN_SECONDS = 10
 TIMEOUT_MESSAGE = "Request timed out. Don't be naughty."
 
 
 SCRIPT = "plugins/_haskell.sh"
-SHELL_COMMAND = ["firejail", "timeout", f"{TIMEOUT_IN_SECONDS}", "bash", SCRIPT]
+SHELL_COMMAND = ["bash", SCRIPT]
 
 
 def main(bot, author_id, code, thread_id, thread_type, **kwargs):

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -28,10 +28,6 @@ def attempt_to_run(code):
 
 def run(code):
     process = Popen(SHELL_COMMAND, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
-    return communicate(process, code)
-
-
-def communicate(process, code):
     encoding = "utf-8"
     code_bytes = code.encode(encoding)
     write_code_to_process = lambda: process.communicate(input=code_bytes)

--- a/steely/plugins/haskell.py
+++ b/steely/plugins/haskell.py
@@ -11,6 +11,9 @@ __author__ = "byxor"
 
 
 TIMEOUT_IN_SECONDS = 10
+TIMEOUT_MESSAGE = "Request timed out. Don't be naughty."
+
+
 SCRIPT = "plugins/_haskell.sh"
 SHELL_COMMAND = ["firejail", "timeout", f"{TIMEOUT_IN_SECONDS}", "bash", SCRIPT]
 
@@ -22,7 +25,7 @@ def main(bot, author_id, code, thread_id, thread_type, **kwargs):
 def attempt_to_run(code):
     result = run(code)
     if timed_out(result):
-        return "Request timed out. Don't be naughty."
+        return TIMEOUT_MESSAGE
     return result
 
 

--- a/steely/plugins/lastfm.py
+++ b/steely/plugins/lastfm.py
@@ -1,23 +1,4 @@
 #!/usr/bin/env python3
-"""
-np does last fm stuff
-
-set your username:
-.np set <username>
-
-check whats your listening to:
-.np [username]
-.np top <overall|7day|1month|3month|6month|12month> [username]
-.np history [username]
-
-make a collage:
-.np collage <overall|7day|1month|3month|6month|12month> [username]
-
-scrobbles:
-.np list
-"""
-
-
 from plugins._lastfm_helpers import *
 from plugins import _lastfm_collage
 from plugins import _lastfm_history
@@ -35,6 +16,24 @@ SUBCOMMANDS = {
     'set':     _lastfm_set.main,
     'top':     _lastfm_top.main,
 }
+
+__doc__ = f"""
+np does last fm stuff
+
+set your username:
+{COMMAND} set <username>
+
+check what you're listening to:
+{COMMAND} [username]
+{COMMAND} top <overall|7day|1month|3month|6month|12month> [username]
+{COMMAND} history [username]
+
+make a collage:
+{COMMAND} collage <overall|7day|1month|3month|6month|12month> [username]
+
+scrobbles:
+{COMMAND} list
+"""
 
 
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):


### PR DESCRIPTION
# Description

* Evaluates a haskell file.
* Shows compiler output.
* Long-running programs are killed (no infinite loops).
* FileSystem is protected from reads/writes.
* Network connections are currently allowed (afaik).

# Setup
* Install `ghc` (haskell compiler).
* Install `firejail` (preferably from source) (sandboxing program).
* `ulimit -u 250` to prevent forkbombs.

Refrain from holding back the review because there's a setup process involved. There's no standard "setup script" kind of system yet, and I don't intend to implement one in this PR. I also don't intend to duplicate setup information.

# Examples

## Simple Expression
```haskell
.haskell main = print (9 + 10)
```
```
Compiler Output:
[1 of 1] Compiling Main             ( temporary/code.hs, temporary/code.o )
Linking temporary/main ...

Program Output:
19
```

## Fibonacci

```haskell
.haskell --

fibonacci :: Integer -> Integer
fibonacci 0 = 1
fibonacci 1 = 1
fibonacci n = fibonacci (n - 1) + fibonacci (n - 2)

main = print (map fibonacci [1..20])
```

```
Compiler Output:
[1 of 1] Compiling Main             ( temporary/code.hs, temporary/code.o )
Linking temporary/main ...

Program Output:
[1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,6765,10946]
```

**Note:** `--` is an empty comment. This is necessary due to the way steely parses messages. Without the comment, the code gets cut off and is invisible to the haskell plugin. Plzfix command parsing. The error is probably something to do with `message.split`.