### PR TITLE
Pin emoji.json to the version before it was deleted

### DIFF
--- a/steely/plugins/sheriff.py
+++ b/steely/plugins/sheriff.py
@@ -17,7 +17,7 @@ def parse_emoji_data(url):
 
 COMMAND = 'sheriff'
 TEMPLATE = """⠀ ⠀ ⠀  🤠\n　   {emoji}{emoji}{emoji}\n    {emoji}   {emoji}　{emoji}\n   👇   {emoji}{emoji} 👇\n  　  {emoji}　{emoji}\n　   {emoji}　 {emoji}\n　   👢     👢\nhowdy. i'm the sheriff of {name}"""
-EMOJI_URL = 'https://raw.githubusercontent.com/muan/emojilib/master/emojis.json'
+EMOJI_URL = 'https://raw.githubusercontent.com/muan/emojilib/52f94fabd98f73a1fd42aa5d6a8eac86c397e5af/emojis.json'
 EMOJI_DATA = parse_emoji_data(EMOJI_URL)
 
 


### PR DESCRIPTION
The emojis JSON file was deleted in [this](https://github.com/muan/emojilib/commit/c65bc776ea3bf12a237ce633e265fb0283864906#diff-3e9c4fe5b103cf8bde2916191149be6c62bab82c2e22f3d0e0c8840d1dc81507) commit for some reason.

This just hardcodes the latest commit with the file still there.